### PR TITLE
Remove font classes on html selector

### DIFF
--- a/script/script.js
+++ b/script/script.js
@@ -136,6 +136,7 @@ function update(event, fallback) {
 	//var thisFb = fb;
 	/*getPos = $("input.textfield").position();
 	if (getPos.top >= 0) {*/
+	$("html").removeClass();
 	$("input.textfield").blur();
 		event.preventDefault();
 		$(".fb_toggle").show(100);


### PR DESCRIPTION
When a font is loaded from the API all current classes are now removed
from the html selector.